### PR TITLE
Adding Research Data info for Dundee, Aberdeen and Strathclyde

### DIFF
--- a/FE.md
+++ b/FE.md
@@ -18,6 +18,7 @@ Last year I identified the open data published by two universities (__*__). Thes
 |Abertay Uni| [URL](https://rke.abertay.ac.uk/en/datasets/)| 10|O|Copyright Elsevier?|
 |University of Dundee| [URL](https://discovery.dundee.ac.uk/en/datasets/) | 47|O| |
 |Edina (Edinburgh Uni)| [URL](https://datashare.is.ed.ac.uk/discover?filtertype=dsType&filter_relational_operator=equals&filter=dataset) |1095|O| |
+|University of Strathclyde| [URL](https://pureportal.strath.ac.uk/en/datasets/)| 964|O| |
 |UBDC (Glasgow Uni)|[URL](http://ubdc.gla.ac.uk/dataset)|1032| 0| |
 
 - Edinburgh __*__
@@ -29,7 +30,6 @@ Last year I identified the open data published by two universities (__*__). Thes
 - Robert Gordon Uni
 - St Andrews
 - Stirling
-- Strathclyde
 - University of Highland and Islands
 - University of West of Scotland
 

--- a/FE.md
+++ b/FE.md
@@ -15,11 +15,11 @@ Last year I identified the open data published by two universities (__*__). Thes
 | Organisation      | URL       | Datasets| Type |Notes|
 | :------------- |:-------------|:------:|:------:|:------:|
 |Abertay Uni| [URL](https://rke.abertay.ac.uk/en/datasets/)| 10|O|Copyright Elsevier?|
+|University of Dundee| [URL](https://discovery.dundee.ac.uk/en/datasets/) | 47| |
 |Edina (Edinburgh Uni)| [URL](https://datashare.is.ed.ac.uk/discover?filtertype=dsType&filter_relational_operator=equals&filter=dataset) |1095|O| |
 |UBDC (Glasgow Uni)|[URL](http://ubdc.gla.ac.uk/dataset)|1032| 0| |
 
 - Aberdeen
-- Dundee
 - Edinburgh __*__
 - Glasgow __*__
 - Glasgow Caledonian

--- a/FE.md
+++ b/FE.md
@@ -14,12 +14,12 @@ Last year I identified the open data published by two universities (__*__). Thes
 
 | Organisation      | URL       | Datasets| Type |Notes|
 | :------------- |:-------------|:------:|:------:|:------:|
+|University of Aberdeen| [URL](https://abdn.pure.elsevier.com/en/datasets/)| 309|O| |
 |Abertay Uni| [URL](https://rke.abertay.ac.uk/en/datasets/)| 10|O|Copyright Elsevier?|
-|University of Dundee| [URL](https://discovery.dundee.ac.uk/en/datasets/) | 47| |
+|University of Dundee| [URL](https://discovery.dundee.ac.uk/en/datasets/) | 47|O| |
 |Edina (Edinburgh Uni)| [URL](https://datashare.is.ed.ac.uk/discover?filtertype=dsType&filter_relational_operator=equals&filter=dataset) |1095|O| |
 |UBDC (Glasgow Uni)|[URL](http://ubdc.gla.ac.uk/dataset)|1032| 0| |
 
-- Aberdeen
 - Edinburgh __*__
 - Glasgow __*__
 - Glasgow Caledonian


### PR DESCRIPTION

You'll note that they all look very similar. That's because they use the some underlying software packge "PURE" from Elsevier - like Abertay. Your comments re the copyright notice, I think, are for the software interface - as it is a commercial product - not the datasets hosted by it. They are individually licenced as per the wishes of the funder and researcher.